### PR TITLE
Do not copy reference assemblies locally

### DIFF
--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.11.0.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.11.0.csproj
@@ -143,9 +143,7 @@
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.DTE.7.0.3\lib\net20\stdole.dll</HintPath>
     </Reference>
-    <Reference Include="System">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll</HintPath>
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.12.0.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.12.0.csproj
@@ -147,19 +147,10 @@
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.DTE.7.0.3\lib\net20\stdole.dll</HintPath>
     </Reference>
-    <Reference Include="System">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ComponentModel.Composition">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.ComponentModel.Composition.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Data.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Transactions" />

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.Roslyn.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.Roslyn.csproj
@@ -147,23 +147,14 @@
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.DTE.7.0.3\lib\net20\stdole.dll</HintPath>
     </Reference>
-    <Reference Include="System">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll</HintPath>
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\Microsoft.Bcl.Immutable.1.1.20-beta\lib\portable-net45+win8\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.ComponentModel.Composition.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Data.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Reflection.Metadata">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,3 +12,6 @@ build:
   verbosity: minimal
 artifacts:
 - path: 'Tvl.VisualStudio.InheritanceMargin\bin\Release\Tvl.VisualStudio.InheritanceMargin.vsix'
+# preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
+cache:
+  - packages -> **\packages.config


### PR DESCRIPTION
This reduces the size of the final package, which currently contains **System.dll** and **System.ComponentModel.Composition.dll**.