### PR TITLE
Eliminate the Solution references in TypeTarget and MemberTarget

### DIFF
--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/AbstractTarget.cs
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/AbstractTarget.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+namespace Tvl.VisualStudio.InheritanceMargin.CSharp
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Text;
+
+    internal abstract class AbstractTarget : IInheritanceTarget
+    {
+        private readonly SourceTextContainer _textContainer;
+        private readonly ProjectId _projectId;
+        private readonly string _displayName;
+        private readonly KeyValuePair<SymbolKind, string>[] _symbolPath;
+
+        protected AbstractTarget(SourceTextContainer textContainer, Project currentProject, Solution solution, ISymbol symbol)
+        {
+            Project project = solution.GetProject(symbol.ContainingAssembly) ?? currentProject;
+
+            _textContainer = textContainer;
+            _projectId = project.Id;
+            _displayName = symbol.ToString();
+
+            List<KeyValuePair<SymbolKind, string>> symbolPath = new List<KeyValuePair<SymbolKind, string>>();
+            for (ISymbol currentSymbol = symbol.OriginalDefinition; currentSymbol != null; currentSymbol = currentSymbol.ContainingSymbol)
+            {
+                ImmutableArray<IParameterSymbol> parameters = default(ImmutableArray<IParameterSymbol>);
+                ImmutableArray<ITypeParameterSymbol> typeParameters = default(ImmutableArray<ITypeParameterSymbol>);
+                switch (currentSymbol.Kind)
+                {
+                case SymbolKind.Method:
+                    parameters = ((IMethodSymbol)currentSymbol).Parameters;
+                    typeParameters = ((IMethodSymbol)currentSymbol).TypeParameters;
+                    break;
+
+                case SymbolKind.Property:
+                    parameters = ((IPropertySymbol)currentSymbol).Parameters;
+                    break;
+
+                default:
+                    break;
+                }
+
+                if (!parameters.IsDefaultOrEmpty)
+                {
+                    for (int i = parameters.Length - 1; i >= 0; i--)
+                    {
+                        symbolPath.Add(new KeyValuePair<SymbolKind, string>(SymbolKind.Parameter, parameters[i].ToString()));
+                    }
+                }
+
+                if (currentSymbol.Kind == SymbolKind.Namespace && ((INamespaceSymbol)currentSymbol).IsGlobalNamespace)
+                    break;
+
+                if (currentSymbol.Kind == SymbolKind.NetModule || currentSymbol.Kind == SymbolKind.Assembly)
+                    break;
+
+                string metadataName = currentSymbol.MetadataName;
+                if (currentSymbol.Kind == SymbolKind.Method && !typeParameters.IsDefaultOrEmpty)
+                    metadataName = metadataName + '`' + typeParameters.Length;
+
+                symbolPath.Add(new KeyValuePair<SymbolKind, string>(currentSymbol.Kind, metadataName));
+            }
+
+            symbolPath.Reverse();
+            _symbolPath = symbolPath.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public string DisplayName
+        {
+            get
+            {
+                return _displayName;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void NavigateTo()
+        {
+            CSharpInheritanceAnalyzer.NavigateToSymbol(_textContainer, _projectId, _symbolPath);
+        }
+    }
+}

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/MemberTarget.cs
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/MemberTarget.cs
@@ -6,32 +6,11 @@ namespace Tvl.VisualStudio.InheritanceMargin.CSharp
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Text;
 
-    internal sealed class MemberTarget : IInheritanceTarget
+    internal sealed class MemberTarget : AbstractTarget
     {
-        private readonly SourceTextContainer _textContainer;
-        private readonly ISymbol _memberIdentifier;
-        private readonly Solution _solution;
-
-        public MemberTarget(SourceTextContainer textContainer, ISymbol memberIdentifier, Solution solution)
+        public MemberTarget(SourceTextContainer textContainer, Project currentProject, Solution solution, ISymbol symbol)
+            : base(textContainer, currentProject, solution, symbol)
         {
-            _textContainer = textContainer;
-            _memberIdentifier = memberIdentifier;
-            _solution = solution;
-        }
-
-        /// <inheritdoc/>
-        public string DisplayName
-        {
-            get
-            {
-                return _memberIdentifier.ToString();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void NavigateTo()
-        {
-            CSharpInheritanceAnalyzer.NavigateToSymbol(_textContainer, _memberIdentifier, _solution.GetProject(_memberIdentifier.ContainingAssembly));
         }
     }
 }

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.14.0.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.14.0.csproj
@@ -209,6 +209,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbstractTarget.cs" />
     <Compile Include="BackgroundParser.cs" />
     <Compile Include="CSharpInheritanceAnalyzer.cs" />
     <Compile Include="MemberTarget.cs" />

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.15.0.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.15.0.csproj
@@ -274,6 +274,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbstractTarget.cs" />
     <Compile Include="BackgroundParser.cs" />
     <Compile Include="CSharpInheritanceAnalyzer.cs" />
     <Compile Include="MemberTarget.cs" />

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.Roslyn.csproj
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/Tvl.VisualStudio.InheritanceMargin.CSharp.Roslyn.csproj
@@ -183,6 +183,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbstractTarget.cs" />
     <Compile Include="BackgroundParser.cs" />
     <Compile Include="CSharpInheritanceAnalyzer.cs" />
     <Compile Include="MemberTarget.cs" />

--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/TypeTarget.cs
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/TypeTarget.cs
@@ -6,32 +6,11 @@ namespace Tvl.VisualStudio.InheritanceMargin.CSharp
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Text;
 
-    internal sealed class TypeTarget : IInheritanceTarget
+    internal sealed class TypeTarget : AbstractTarget
     {
-        private readonly SourceTextContainer _textContainer;
-        private readonly ISymbol _typeIdentifier;
-        private readonly Solution _solution;
-
-        public TypeTarget(SourceTextContainer textContainer, ISymbol typeIdentifier, Solution solution)
+        public TypeTarget(SourceTextContainer textContainer, Project currentProject, Solution solution, ISymbol symbol)
+            : base(textContainer, currentProject, solution, symbol)
         {
-            _textContainer = textContainer;
-            _typeIdentifier = typeIdentifier;
-            _solution = solution;
-        }
-
-        /// <inheritdoc/>
-        public string DisplayName
-        {
-            get
-            {
-                return _typeIdentifier.ToString();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void NavigateTo()
-        {
-            CSharpInheritanceAnalyzer.NavigateToSymbol(_textContainer, _typeIdentifier, _solution.GetProject(_typeIdentifier.ContainingAssembly));
         }
     }
 }


### PR DESCRIPTION
Fixes memory leaks and large working set requirements.