### PR TITLE
Version updates

### DIFF
--- a/Tvl.VisualStudio.InheritanceMargin.CSharp/CSharpInheritanceAnalyzer.cs
+++ b/Tvl.VisualStudio.InheritanceMargin.CSharp/CSharpInheritanceAnalyzer.cs
@@ -98,7 +98,8 @@ namespace Tvl.VisualStudio.InheritanceMargin.CSharp
             new Lazy<Func<INamedTypeSymbol, Solution, IImmutableSet<Project>, CancellationToken, Task<IEnumerable<INamedTypeSymbol>>>>(() =>
             {
 #if ROSLYN2
-                if (FindImmediatelyDerivedAndImplementingTypesAsyncMethodInfo.Value is MethodInfo method)
+                if (FindImmediatelyDerivedAndImplementingTypesAsyncMethodInfo.Value is MethodInfo method
+                    && method.ReturnType == typeof(Task<ImmutableArray<INamedTypeSymbol>>))
                 {
                     // Roslyn 3.7-beta1 switched back to the form from Roslyn 1.3, with the exception of the return type.
                     var immediatelyDerived = (Func<INamedTypeSymbol, Solution, CancellationToken, Task<ImmutableArray<INamedTypeSymbol>>>)Delegate.CreateDelegate(typeof(Func<INamedTypeSymbol, Solution, CancellationToken, Task<ImmutableArray<INamedTypeSymbol>>>), method);


### PR DESCRIPTION
* Fix support for derived interfaces prior to 16.6 (was broken by #52)
* Fix support for derived interfaces in 16.6 (was broken by dotnet/roslyn#43029 but never fixed here)